### PR TITLE
LWDEV-7921 Make width of the Y labels for the Depth chart fixed

### DIFF
--- a/src/components/DepthChart/Chart/Mesh.tsx
+++ b/src/components/DepthChart/Chart/Mesh.tsx
@@ -4,7 +4,6 @@ import {Order} from '../../../models';
 
 import formattedNumber from '../../../utils/localFormatted/localFormatted';
 import chart from './chartConstants';
-import {measureText} from './chartHelpers';
 
 interface MeshProps {
   asks: Order[];
@@ -14,7 +13,6 @@ interface MeshProps {
   quoteAccuracy: number;
   baseAccuracy: number;
   priceAccuracy: number;
-  setLabelsWidth: (width: number) => {};
 }
 
 class Mesh extends React.Component<MeshProps> {
@@ -200,18 +198,6 @@ class Mesh extends React.Component<MeshProps> {
     }
   };
 
-  setHorizontalLabelsBarWidth = (labels: React.ReactText[]) => {
-    const longestLabelLength = Math.max(
-      ...labels.map(label => label.toString().length)
-    );
-    const labelsWidth = measureText(
-      '8'.repeat(longestLabelLength),
-      chart.mesh.horizontalFontSize,
-      chart.mesh.fontFamily
-    );
-    this.props.setLabelsWidth(labelsWidth + 10);
-  };
-
   drawHorizontalLabels = () => {
     const stepHorizontal = this.props.height / chart.mesh.horizontalLinesAmount;
     const startHorizontal = stepHorizontal / 2;
@@ -255,12 +241,6 @@ class Mesh extends React.Component<MeshProps> {
     this.renderMesh();
     this.renderLabels();
     return this.mesh;
-  }
-
-  componentDidUpdate() {
-    if (this.labels.length > 0) {
-      this.setHorizontalLabelsBarWidth(this.labels);
-    }
   }
 }
 

--- a/src/components/DepthChart/Chart/Mesh.tsx
+++ b/src/components/DepthChart/Chart/Mesh.tsx
@@ -74,17 +74,10 @@ class Mesh extends React.Component<MeshProps> {
   };
 
   calculateMaxDepth = () => {
-    if (this.props.asks.length > 0 && this.props.bids.length > 0) {
-      return Math.max(
-        ...this.props.asks.map(a => a.depth),
-        ...this.props.bids.map(b => b.depth)
-      );
-    } else if (this.props.asks.length > 0) {
-      return Math.max(...this.props.asks.map(a => a.depth));
-    } else if (this.props.bids.length > 0) {
-      return Math.max(...this.props.bids.map(b => b.depth));
-    }
-    return 1;
+    return Math.max(
+      ...this.props.asks.map(a => a.depth),
+      ...this.props.bids.map(b => b.depth)
+    );
   };
 
   generateHorizontalLabels = () => {

--- a/src/components/DepthChart/Chart/Mesh.tsx
+++ b/src/components/DepthChart/Chart/Mesh.tsx
@@ -76,13 +76,13 @@ class Mesh extends React.Component<MeshProps> {
   calculateMaxDepth = () => {
     if (this.props.asks.length > 0 && this.props.bids.length > 0) {
       return Math.max(
-        this.props.asks[0].depth,
-        this.props.bids[this.props.bids.length - 1].depth
+        ...this.props.asks.map(a => a.depth),
+        ...this.props.bids.map(b => b.depth)
       );
     } else if (this.props.asks.length > 0) {
-      return this.props.asks[0].depth;
+      return Math.max(...this.props.asks.map(a => a.depth));
     } else if (this.props.bids.length > 0) {
-      return this.props.bids[this.props.bids.length - 1].depth;
+      return Math.max(...this.props.bids.map(b => b.depth));
     }
     return 1;
   };

--- a/src/components/DepthChart/Chart/chartConstants.ts
+++ b/src/components/DepthChart/Chart/chartConstants.ts
@@ -63,7 +63,7 @@ const chart = {
   strokeWidth: 2,
   fillOpacity: 0.2,
 
-  labelsWidth: 40,
+  labelsWidth: 50,
   labelsHeight: 25,
 
   labelsAccuracy: 2,

--- a/src/components/DepthChart/Chart/index.tsx
+++ b/src/components/DepthChart/Chart/index.tsx
@@ -21,27 +21,19 @@ const ConnectedChartWrapper: any = connect(
 
 const ConnectedMesh = connect(
   ({
-    depthChartStore: {
-      getAsks,
-      getBids,
-      height,
-      width,
-      setLabelsWidth,
-      labelsWidth
-    },
+    depthChartStore: {getAsks, getBids, height, width},
     uiStore: {selectedInstrument}
   }) => {
     return {
       asks: getAsks,
       bids: getBids,
       height: height - chart.labelsHeight,
-      width: width - labelsWidth,
+      width: width - chart.labelsWidth,
       baseAsset: selectedInstrument!.baseAsset.name,
       quoteAsset: selectedInstrument!.quoteAsset.name,
       quoteAccuracy: selectedInstrument!.quoteAsset.accuracy,
       baseAccuracy: selectedInstrument!.baseAsset.accuracy,
-      priceAccuracy: selectedInstrument!.accuracy,
-      setLabelsWidth
+      priceAccuracy: selectedInstrument!.accuracy
     };
   },
   Mesh
@@ -49,14 +41,14 @@ const ConnectedMesh = connect(
 
 const ConnectedChart = connect(
   ({
-    depthChartStore: {getAsks, getBids, height, width, labelsWidth},
+    depthChartStore: {getAsks, getBids, height, width},
     uiStore: {selectedInstrument}
   }) => {
     return {
       asks: reverse(getAsks),
       bids: getBids,
       height: height - chart.labelsHeight,
-      width: width - labelsWidth,
+      width: width - chart.labelsWidth,
       baseAsset: selectedInstrument!.baseAsset.name,
       quoteAsset: selectedInstrument!.quoteAsset.name,
       quoteAccuracy: selectedInstrument!.quoteAsset.accuracy,
@@ -68,13 +60,10 @@ const ConnectedChart = connect(
 );
 
 const ConnectedPointer = connect(
-  ({
-    depthChartStore: {height, width, labelsWidth},
-    uiStore: {selectedInstrument}
-  }) => {
+  ({depthChartStore: {height, width}, uiStore: {selectedInstrument}}) => {
     return {
       height: height - chart.labelsHeight,
-      width: width - labelsWidth,
+      width: width - chart.labelsWidth,
       baseAsset: selectedInstrument!.baseAsset.name,
       quoteAsset: selectedInstrument!.quoteAsset.name,
       quoteAccuracy: selectedInstrument!.quoteAsset.accuracy,

--- a/src/stores/depthChartStore.ts
+++ b/src/stores/depthChartStore.ts
@@ -1,6 +1,5 @@
 import {action, computed, observable} from 'mobx';
 import {reverse} from 'rambda';
-import chart from '../components/DepthChart/Chart/chartConstants';
 import {Order, TradeModel} from '../models';
 import {precisionFloor} from '../utils/math';
 import {BaseStore, RootStore} from './index';
@@ -12,7 +11,6 @@ class DepthChartStore extends BaseStore {
   @observable spanMultiplierIdx = 3;
   @observable width: number = 1024;
   @observable height: number = 512;
-  @observable labelsWidth: number = chart.labelsWidth;
   @observable asks: Order[] = [];
   @observable bids: Order[] = [];
 
@@ -132,11 +130,6 @@ class DepthChartStore extends BaseStore {
   @action
   setHeight = (height: number) => {
     this.height = height;
-  };
-
-  @action
-  setLabelsWidth = (width: number) => {
-    this.labelsWidth = width > chart.labelsWidth ? width : chart.labelsWidth;
   };
 
   @computed


### PR DESCRIPTION
https://lykkex.atlassian.net/browse/LWDEV-7921

`labelsWidth` is now 50 points long (width of the longest possible string `000,00` + margin);

Max order depth is now calculated explicitly.